### PR TITLE
fix: Router collision

### DIFF
--- a/src/application/routers/Router.tsx
+++ b/src/application/routers/Router.tsx
@@ -3,12 +3,17 @@ import { Route, Routes as RouterRoutes } from 'react-router'
 import { ROUTES, ROUTE_PAGES } from './routes'
 
 export function Router() {
+  const HomePage = ROUTE_PAGES[ROUTES.HOME]
+  const RepairsPage = ROUTE_PAGES[ROUTES.REPAIRS]
+  const RepairCreatePage = ROUTE_PAGES[ROUTES.REPAIR_CREATE]
+  const RepairDetailPage = ROUTE_PAGES[ROUTES.REPAIR_DETAIL]
+
   return (
     <RouterRoutes>
-      {Object.entries(ROUTES).map(([key, path]) => {
-        const Page = ROUTE_PAGES[path]
-        return <Route key={key} path={path} element={<Page />} />
-      })}
+      <Route path={ROUTES.HOME} element={<HomePage />} />
+      <Route path={ROUTES.REPAIRS} element={<RepairsPage />} />
+      <Route path={ROUTES.REPAIR_CREATE} element={<RepairCreatePage />} />
+      <Route path={ROUTES.REPAIR_DETAIL} element={<RepairDetailPage />} />
     </RouterRoutes>
   )
 }

--- a/src/presentation/pages/RepairCreatePage/RepairCreatePageViewMobile.tsx
+++ b/src/presentation/pages/RepairCreatePage/RepairCreatePageViewMobile.tsx
@@ -2,6 +2,7 @@ import { css, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useNavigate } from 'react-router'
 
+import { ROUTES } from '@/application/routers/routes'
 import { Header } from '@/presentation/components/Header'
 import { SOORITheme } from '@/theme/soori_theme'
 
@@ -19,7 +20,7 @@ export function RepairCreatePageViewMobile() {
           title="전동보장구 정비사항 작성"
           description="PM2024007 • 라이언"
           onBack={() => {
-            void navigate(-1)
+            void navigate(ROUTES.REPAIRS)
           }}
         />
       </StickyTop>

--- a/src/presentation/pages/RepairDetailPage/RepairDetailPageViewMobile.tsx
+++ b/src/presentation/pages/RepairDetailPage/RepairDetailPageViewMobile.tsx
@@ -2,6 +2,7 @@ import { css, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useNavigate } from 'react-router'
 
+import { ROUTES } from '@/application/routers/routes'
 import { Header } from '@/presentation/components/Header'
 import { SOORITheme } from '@/theme/soori_theme'
 
@@ -16,7 +17,7 @@ export function RepairDetailPageViewMobile() {
           title="전동보장구 정비이력 확인"
           description="PM2024007 • 라이언"
           onBack={() => {
-            void navigate(-1)
+            void navigate(ROUTES.REPAIRS)
           }}
         />
       </StickyTop>

--- a/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
@@ -2,7 +2,7 @@ import { css, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Link, useNavigate } from 'react-router'
 
-import { buildRoute } from '@/application/routers/routes'
+import { buildRoute, ROUTES } from '@/application/routers/routes'
 import { Calendar, ChevronRight, Search } from '@/assets/svgs/svgs'
 import { RepairModel } from '@/domain/models/models'
 import { Header, Tabs } from '@/presentation/components/components'
@@ -24,7 +24,11 @@ export function RepairsPageViewMobile() {
           return (
             <Container>
               <StickyTop theme={theme}>
-                <Header title="전동보장구 정비이력" description="PM2024007 • 라이언" onBack={() => void navigate(-1)} />
+                <Header
+                  title="전동보장구 정비이력"
+                  description="PM2024007 • 라이언"
+                  onBack={() => void navigate(ROUTES.HOME)}
+                />
                 <Tabs
                   activeTab={viewModel.activeTab as string}
                   setActiveTab={(tabId: string) => {


### PR DESCRIPTION
## 라우터 충돌을 해결합니다
- /repairs/new와 /repairs/:id의 충돌을 해결합니다
- navigate(-1) 대신 페이지를 명시하여 이동하도록 합니다