### PR TITLE
fix: `BuildRoute()` for empty queryString key

### DIFF
--- a/src/application/routers/routes.ts
+++ b/src/application/routers/routes.ts
@@ -41,6 +41,7 @@ export const buildRoute = (
   })
 
   const queryString = Object.entries(queryParams)
+    .filter(([, value]) => value !== '')
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join('&')
 


### PR DESCRIPTION
## 빈 쿼리스트링 key를 대응하기 위해 `buildRoute()`를 수정합니다
- key가 비어있다면 build하지 않도록 `filter()`를 추가하였습니다