### PR TITLE
fix: Rename RepairsViewModel

### DIFF
--- a/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
@@ -9,11 +9,11 @@ import { RepairModel } from '@/domain/models/models'
 import { Header, Tabs } from '@/presentation/components/components'
 import { SOORITheme } from '@/theme/soori_theme'
 
-import { TabId, useRepairViewModel } from './RepairsPageViewModel'
+import { TabId, useRepairsViewModel } from './RepairsPageViewModel'
 
 export const RepairsPageViewMobile = observer(() => {
   const theme = useTheme()
-  const viewModel = useRepairViewModel()
+  const viewModel = useRepairsViewModel()
 
   return (
     <>
@@ -58,7 +58,7 @@ export const RepairsPageViewMobile = observer(() => {
 
 const AuthModal = observer(() => {
   const theme = useTheme()
-  const viewModel = useRepairViewModel()
+  const viewModel = useRepairsViewModel()
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -100,7 +100,7 @@ const AuthModal = observer(() => {
 
 const SearchBar = observer(() => {
   const theme = useTheme()
-  const viewModel = useRepairViewModel()
+  const viewModel = useRepairsViewModel()
 
   return (
     <SearchBarOuterContainer theme={theme}>
@@ -124,7 +124,7 @@ const SearchBar = observer(() => {
 })
 
 const RepairHistoryList = observer(() => {
-  const viewModel = useRepairViewModel()
+  const viewModel = useRepairsViewModel()
 
   return (
     <RepairList aria-label="정비 이력 목록">
@@ -141,7 +141,7 @@ interface RepairItemProps {
 
 const RepairHistoryItem = ({ repair }: RepairItemProps) => {
   const theme = useTheme()
-  const viewModel = useRepairViewModel()
+  const viewModel = useRepairsViewModel()
 
   return (
     <RepairCard

--- a/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
@@ -146,7 +146,7 @@ class RepairsStore {
 
 const store = new RepairsStore()
 
-export function useRepairViewModel() {
+export function useRepairsViewModel() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const vehicleId = searchParams.get('vehicleId') ?? ''

--- a/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
@@ -23,7 +23,7 @@ const tabItems: TabItem[] = [
   { id: TabId.VEHICLE, label: '전동보장구 정보' },
 ]
 
-class RepairsPageStore {
+class RepairsStore {
   repairs: RepairModel[] = []
   searchKeyword = ''
   activeTab: TabId = TabId.REPAIRS
@@ -144,7 +144,7 @@ class RepairsPageStore {
   }
 }
 
-const store = new RepairsPageStore()
+const store = new RepairsStore()
 
 export function useRepairViewModel() {
   const navigate = useNavigate()


### PR DESCRIPTION
## RepairsViewModel에서 네이밍 컨벤션을 지키도록 합니다
- `useRepairViewModel` -> `useRepairsViewModel`
- `RepairsPageStore` -> `RepairsStore`