### PR TITLE
feat: Add hover opacity in global style

### DIFF
--- a/src/theme/styles/GlobalStyle.tsx
+++ b/src/theme/styles/GlobalStyle.tsx
@@ -46,6 +46,19 @@ export function GlobalStyle() {
           font: inherit;
           color: inherit;
           cursor: pointer;
+
+          :hover {
+            opacity: 0.7;
+          }
+        }
+
+        a,
+        input,
+        label,
+        textarea {
+          :hover {
+            opacity: 0.7;
+          }
         }
 
         ul,


### PR DESCRIPTION
## GlobalStyle에 hover 이펙트를 추가합니다
-  `a`, `input`, `label`, `textarea`에 hover시 opacity 70% 효과를 줍니다