### PR TITLE
refactor: Migrate to RouterProvider and lazy loading

### DIFF
--- a/src/application/apps/App.tsx
+++ b/src/application/apps/App.tsx
@@ -1,16 +1,15 @@
 import { ThemeProvider } from '@emotion/react'
-import { BrowserRouter } from 'react-router'
+import { RouterProvider } from 'react-router'
 
-import { Router } from '@/application/routers/routers'
 import { SOORITheme, GlobalStyle } from '@/theme/theme'
+
+import { router } from '../routers/Router'
 
 export function App() {
   return (
-    <BrowserRouter>
-      <ThemeProvider theme={SOORITheme}>
-        <GlobalStyle />
-        <Router />
-      </ThemeProvider>
-    </BrowserRouter>
+    <ThemeProvider theme={SOORITheme}>
+      <GlobalStyle />
+      <RouterProvider router={router} />
+    </ThemeProvider>
   )
 }

--- a/src/application/apps/App.tsx
+++ b/src/application/apps/App.tsx
@@ -3,7 +3,7 @@ import { RouterProvider } from 'react-router'
 
 import { SOORITheme, GlobalStyle } from '@/theme/theme'
 
-import { router } from '../routers/Router'
+import { router } from '../routers/routers'
 
 export function App() {
   return (

--- a/src/application/routers/Router.tsx
+++ b/src/application/routers/Router.tsx
@@ -1,19 +1,29 @@
-import { Route, Routes as RouterRoutes } from 'react-router'
+import { lazy } from 'react'
 
-import { ROUTES, ROUTE_PAGES } from './routes'
+import { createBrowserRouter } from 'react-router'
 
-export function Router() {
-  const HomePage = ROUTE_PAGES[ROUTES.HOME]
-  const RepairsPage = ROUTE_PAGES[ROUTES.REPAIRS]
-  const RepairCreatePage = ROUTE_PAGES[ROUTES.REPAIR_CREATE]
-  const RepairDetailPage = ROUTE_PAGES[ROUTES.REPAIR_DETAIL]
+import { ROUTES } from './routes'
 
-  return (
-    <RouterRoutes>
-      <Route path={ROUTES.HOME} element={<HomePage />} />
-      <Route path={ROUTES.REPAIRS} element={<RepairsPage />} />
-      <Route path={ROUTES.REPAIR_CREATE} element={<RepairCreatePage />} />
-      <Route path={ROUTES.REPAIR_DETAIL} element={<RepairDetailPage />} />
-    </RouterRoutes>
-  )
-}
+const HomePage = lazy(() => import('@/presentation/pages/HomePage/HomePageView'))
+const RepairsPage = lazy(() => import('@/presentation/pages/RepairsPage/RepairsPageView'))
+const RepairCreatePage = lazy(() => import('@/presentation/pages/RepairCreatePage/RepairCreatePageView'))
+const RepairDetailPage = lazy(() => import('@/presentation/pages/RepairDetailPage/RepairDetailPageView'))
+
+export const router = createBrowserRouter([
+  {
+    path: ROUTES.HOME,
+    element: <HomePage />,
+  },
+  {
+    path: ROUTES.REPAIRS,
+    element: <RepairsPage />,
+  },
+  {
+    path: ROUTES.REPAIR_CREATE,
+    element: <RepairCreatePage />,
+  },
+  {
+    path: ROUTES.REPAIR_DETAIL,
+    element: <RepairDetailPage />,
+  },
+])

--- a/src/application/routers/routers.ts
+++ b/src/application/routers/routers.ts
@@ -1,2 +1,2 @@
-export { Router } from './Router'
+export { router } from './Router'
 export * from './routes'

--- a/src/application/routers/routes.ts
+++ b/src/application/routers/routes.ts
@@ -1,7 +1,3 @@
-import { ComponentType } from 'react'
-
-import { HomePageView, RepairsPageView, RepairDetailPageView, RepairCreatePageView } from '@/presentation/pages/pages'
-
 export const ROUTES = {
   HOME: '/',
   REPAIRS: '/repairs',
@@ -9,16 +5,7 @@ export const ROUTES = {
   REPAIR_CREATE: '/repairs/new',
 } as const
 
-export const ROUTE_PAGES: Record<RoutePath, ComponentType> = {
-  [ROUTES.HOME]: HomePageView,
-  [ROUTES.REPAIRS]: RepairsPageView,
-  [ROUTES.REPAIR_DETAIL]: RepairDetailPageView,
-  [ROUTES.REPAIR_CREATE]: RepairCreatePageView,
-}
-
 export type RouteKey = keyof typeof ROUTES
-
-export type RoutePath = (typeof ROUTES)[RouteKey]
 
 /**
  * 라우트 경로를 생성하는 함수

--- a/src/presentation/pages/HomePage/HomePageView.tsx
+++ b/src/presentation/pages/HomePage/HomePageView.tsx
@@ -1,9 +1,11 @@
 import { HomePageViewMobile } from './HomePageViewMobile'
 
-export function HomePageView() {
+function HomePageView() {
   return (
     <>
       <HomePageViewMobile />
     </>
   )
 }
+
+export default HomePageView

--- a/src/presentation/pages/RepairCreatePage/RepairCreatePageView.tsx
+++ b/src/presentation/pages/RepairCreatePage/RepairCreatePageView.tsx
@@ -1,9 +1,11 @@
 import { RepairCreatePageViewMobile } from './RepairCreatePageViewMobile'
 
-export function RepairCreatePageView() {
+function RepairCreatePageView() {
   return (
     <>
       <RepairCreatePageViewMobile />
     </>
   )
 }
+
+export default RepairCreatePageView

--- a/src/presentation/pages/RepairDetailPage/RepairDetailPageView.tsx
+++ b/src/presentation/pages/RepairDetailPage/RepairDetailPageView.tsx
@@ -1,9 +1,11 @@
 import { RepairDetailPageViewMobile } from './RepairDetailPageViewMobile'
 
-export function RepairDetailPageView() {
+function RepairDetailPageView() {
   return (
     <>
       <RepairDetailPageViewMobile />
     </>
   )
 }
+
+export default RepairDetailPageView

--- a/src/presentation/pages/RepairsPage/RepairsPageView.tsx
+++ b/src/presentation/pages/RepairsPage/RepairsPageView.tsx
@@ -1,9 +1,11 @@
 import { RepairsPageViewMobile } from './RepairsPageViewMobile'
 
-export function RepairsPageView() {
+function RepairsPageView() {
   return (
     <>
       <RepairsPageViewMobile />
     </>
   )
 }
+
+export default RepairsPageView

--- a/src/presentation/pages/pages.ts
+++ b/src/presentation/pages/pages.ts
@@ -1,4 +1,0 @@
-export { default as HomePageView } from './HomePage/HomePageView'
-export { default as RepairCreatePageView } from './RepairCreatePage/RepairCreatePageView'
-export { default as RepairDetailPageView } from './RepairDetailPage/RepairDetailPageView'
-export { default as RepairsPageView } from './RepairsPage/RepairsPageView'

--- a/src/presentation/pages/pages.ts
+++ b/src/presentation/pages/pages.ts
@@ -1,4 +1,4 @@
-export * from './HomePage/HomePageView'
-export * from './RepairCreatePage/RepairCreatePageView'
-export * from './RepairDetailPage/RepairDetailPageView'
-export * from './RepairsPage/RepairsPageView'
+export { default as HomePageView } from './HomePage/HomePageView'
+export { default as RepairCreatePageView } from './RepairCreatePage/RepairCreatePageView'
+export { default as RepairDetailPageView } from './RepairDetailPage/RepairDetailPageView'
+export { default as RepairsPageView } from './RepairsPage/RepairsPageView'


### PR DESCRIPTION
## react-router의 data router로 migrate합니다
- `createBrowserRouter`를 사용하고, lazy로딩을 도입하였습니다