### PR TITLE
feat: Add firebase auth use-cases

### DIFF
--- a/src/domain/use_cases/auth_phone_confirm_use_case.ts
+++ b/src/domain/use_cases/auth_phone_confirm_use_case.ts
@@ -1,0 +1,24 @@
+import { ConfirmationResult, User } from 'firebase/auth'
+
+import { UseCase } from './use_case'
+
+export interface AuthPhoneConfirmParams {
+  verificationCode: string
+  confirmationResult: ConfirmationResult
+}
+
+/**
+ * 전화번호 인증 코드 확인 UseCase
+ *
+ * 사용자가 받은 인증 코드를 확인하여 Firebase 로그인을 완료합니다.
+ */
+export class AuthPhoneConfirmUseCase implements UseCase<Promise<User | null>, AuthPhoneConfirmParams> {
+  /**
+   * 인증 코드 확인
+   * @param value 인증 코드와 이전에 받은 confirmationResult 객체
+   */
+  async call(value: AuthPhoneConfirmParams): Promise<User | null> {
+    const userCredential = await value.confirmationResult.confirm(value.verificationCode)
+    return userCredential.user
+  }
+}

--- a/src/domain/use_cases/auth_phone_verify_use_case.ts
+++ b/src/domain/use_cases/auth_phone_verify_use_case.ts
@@ -1,0 +1,29 @@
+import { Auth, ConfirmationResult, RecaptchaVerifier, signInWithPhoneNumber } from 'firebase/auth'
+
+import { UseCase } from './use_case'
+
+export interface AuthPhoneVerifyParams {
+  auth: Auth
+  phoneNumber: string
+}
+
+export const RECAPTCHA_VERIFIER_ID = 'recaptcha-verifier'
+
+/**
+ * 전화번호 인증 요청 UseCase
+ *
+ * 전화번호를 입력하면 Firebase에서 인증 코드를 SMS로 발송합니다.
+ */
+export class AuthPhoneVerifyUseCase implements UseCase<Promise<ConfirmationResult>, AuthPhoneVerifyParams> {
+  /**
+   * 전화번호 인증 요청
+   * @param value 전화번호
+   */
+  async call(value: AuthPhoneVerifyParams): Promise<ConfirmationResult> {
+    window.recaptcha ??= new RecaptchaVerifier(value.auth, RECAPTCHA_VERIFIER_ID, {
+      size: 'invisible',
+    })
+    const confirmationResult = await signInWithPhoneNumber(value.auth, value.phoneNumber, window.recaptcha)
+    return confirmationResult
+  }
+}

--- a/src/domain/use_cases/use_case.ts
+++ b/src/domain/use_cases/use_case.ts
@@ -1,0 +1,3 @@
+export interface UseCase<T, V> {
+  call(value: V): T
+}

--- a/src/domain/use_cases/use_cases.ts
+++ b/src/domain/use_cases/use_cases.ts
@@ -1,0 +1,2 @@
+export * from './auth_phone_confirm_use_case'
+export * from './auth_phone_verify_use_case'

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  recaptcha?: import('firebase/auth').RecaptchaVerifier
+}


### PR DESCRIPTION
## firebase authentication을 사용하기 위한 use-case를 구현합니다
- SMS 인증을 위해 다음과 같은 use-case를 추가합니다
  - `auth_phone_verify_use_case` : reCAPTCHA 검증 및 인증번호 발송
  - `auth_phone_confirm_use_case` : 인증번호 검증