### PR TITLE
fix: RecaptchaVerifier tabIndex to -1

### DIFF
--- a/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
+++ b/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
@@ -71,13 +71,13 @@ const PhoneInputFormGroup = observer(() => {
         />
         <RequestButton
           theme={theme}
-          id={RECAPTCHA_VERIFIER_ID}
           onClick={async () => {
             await viewModel.requestVerification()
           }}
           disabled={!viewModel.canRequestVerification}
           aria-disabled={!viewModel.canRequestVerification}
         >
+          <RecaptchaVerifier id={RECAPTCHA_VERIFIER_ID} tabIndex={-1} />
           {'인증번호 요청'}
         </RequestButton>
       </InputGroup>
@@ -264,6 +264,10 @@ const RequestButton = styled.button`
   &:disabled {
     cursor: not-allowed;
   }
+`
+
+const RecaptchaVerifier = styled.div`
+  display: none;
 `
 
 const CTAButtonContainer = styled.div`


### PR DESCRIPTION
## reCAPTCHA 요소로 인해 키보드 탐색이 어색했던 문제를 수정합니다
- 중간에 tab을 차지하던 요소에 `tabIndex`를 -1로 설정해주었습니다

### AS-IS
https://github.com/user-attachments/assets/8f14d61f-7411-4f7b-837f-4a6e626877bd



### TO-BE
https://github.com/user-attachments/assets/7cfa9b97-100c-419c-91bf-7818b3ac5783

