### PR TITLE
feat: Use user role with `useUserRole()`

### DIFF
--- a/src/application/routers/ProtectedRoutes.tsx
+++ b/src/application/routers/ProtectedRoutes.tsx
@@ -1,38 +1,10 @@
-import { JSX, useEffect, useState, useRef, useMemo } from 'react'
+import { JSX, useEffect, useRef, useMemo } from 'react'
 
-import { getAuth, onAuthStateChanged, User } from 'firebase/auth'
 import { Navigate, useLocation } from 'react-router'
 
-import { useLoading } from '@/presentation/hooks/hooks'
+import { useLoading, useAuthState } from '@/presentation/hooks/hooks'
 
 import { buildRoute } from './routes'
-
-function useAuthState() {
-  const auth = getAuth()
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(
-      auth,
-      (currentUser) => {
-        setUser(currentUser)
-        setLoading(false)
-      },
-      (err) => {
-        setError(err)
-        setLoading(false)
-      }
-    )
-
-    return () => {
-      unsubscribe()
-    }
-  }, [auth])
-
-  return { user, loading, error }
-}
 
 interface LocationState {
   from?: {
@@ -85,11 +57,6 @@ export const ProtectedRoute = ({ children, requireAuth }: ProtectedRouteProps) =
     previousPageRef.current ??= children
     return previousPageRef.current
   }
-  console.log(
-    (async () => {
-      return await user?.getIdToken()
-    })()
-  )
 
   if (requireAuth && !user) {
     return (

--- a/src/data/repositories/user_repository_soori.ts
+++ b/src/data/repositories/user_repository_soori.ts
@@ -49,4 +49,20 @@ export class UserRepositorySoori implements UserRepository {
       throw error
     }
   }
+
+  async getUserRole(token: string): Promise<string> {
+    try {
+      const config = {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+
+      const response = await this.httpClient.get<{ role: string }>(`${this.baseUrl}/role`, config)
+      return response.role
+    } catch (error) {
+      console.error('사용자 역할 조회 실패:', error)
+      throw error
+    }
+  }
 }

--- a/src/domain/models/user_model.ts
+++ b/src/domain/models/user_model.ts
@@ -37,6 +37,10 @@ export class UserModel implements User {
     this.updatedAt = new Date(model.updatedAt ?? new Date())
   }
 
+  get isUser(): boolean {
+    return this.role === 'user'
+  }
+
   get isAdmin(): boolean {
     return this.role === 'admin'
   }

--- a/src/domain/repositories/user_repository.ts
+++ b/src/domain/repositories/user_repository.ts
@@ -17,4 +17,5 @@ export interface SignUpParams {
 export interface UserRepository {
   checkUserExists(token: string): Promise<CheckUserResponse>
   signUp(token: string, userData: SignUpParams): Promise<UserModel>
+  getUserRole(token: string): Promise<string>
 }

--- a/src/presentation/hooks/hooks.ts
+++ b/src/presentation/hooks/hooks.ts
@@ -1,1 +1,2 @@
 export * from './useLoading'
+export * from './useAuthState'

--- a/src/presentation/hooks/hooks.ts
+++ b/src/presentation/hooks/hooks.ts
@@ -1,2 +1,3 @@
 export * from './useLoading'
+export * from './useUserRole'
 export * from './useAuthState'

--- a/src/presentation/hooks/useAuthState.ts
+++ b/src/presentation/hooks/useAuthState.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+
+import { getAuth, onAuthStateChanged, User } from 'firebase/auth'
+
+export function useAuthState() {
+  const auth = getAuth()
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (currentUser) => {
+        setUser(currentUser)
+        setLoading(false)
+      },
+      (err) => {
+        setError(err)
+        setLoading(false)
+      }
+    )
+
+    return () => {
+      unsubscribe()
+    }
+  }, [auth])
+
+  return { user, loading, error }
+}

--- a/src/presentation/hooks/useUserRole.ts
+++ b/src/presentation/hooks/useUserRole.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { userRepositorySoori } from '@/data/services/services'
+
+import { useAuthState } from './useAuthState'
+
+export const useUserRole = () => {
+  const { user, loading: authLoading } = useAuthState()
+
+  const { data: userRole, isLoading: roleLoading } = useQuery({
+    queryKey: ['role', user?.uid],
+    queryFn: async () => {
+      if (!user) {
+        return null
+      }
+
+      const token = await user.getIdToken()
+      return userRepositorySoori.getUserRole(token)
+    },
+    enabled: !!user,
+  })
+
+  const isLoading = authLoading || roleLoading
+  const isAdmin = userRole === 'admin'
+  const isRepairer = userRole === 'repairer'
+  const isUser = userRole === 'user'
+  const isGuardian = userRole === 'guardian'
+
+  return {
+    userRole,
+    isLoading,
+    isAdmin,
+    isRepairer,
+    isUser,
+    isGuardian,
+  }
+}

--- a/src/presentation/pages/RepairCreatePage/RepairCreatePageViewModel.ts
+++ b/src/presentation/pages/RepairCreatePage/RepairCreatePageViewModel.ts
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 
 import { buildRoute } from '@/application/routers/routes'
 import { RepairCategory, RepairModel } from '@/domain/models/models'
+import { useUserRole } from '@/presentation/hooks/hooks'
 
 class RepairCreateStore {
   repairModel: RepairModel = new RepairModel({})
@@ -129,10 +130,15 @@ const store = new RepairCreateStore()
 export function useRepairCreateViewModel() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
+  const { isUser, isGuardian } = useUserRole()
   const vehicleId = searchParams.get('vehicleId') ?? ''
 
   const submitRepair = () => {
     if (!store.valid) return
+    if (isUser || isGuardian) {
+      alert('정비사항은 관리자만 등록할 수 있습니다.')
+      return
+    }
 
     alert('정비사항이 저장되었습니다.')
     store.resetForm()

--- a/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
@@ -24,7 +24,7 @@ export const RepairsPageViewMobile = observer(() => {
   }, [])
 
   return (
-    <Container>
+    <Container shouldShowCTA={viewModel.shouldShowCTA}>
       <StickyTop theme={theme}>
         <Header title="전동보장구 정비이력" description="PM2024007 • 라이언" />
         <Tabs
@@ -45,13 +45,25 @@ export const RepairsPageViewMobile = observer(() => {
           }
         })()}
       </MainContent>
-      <FloatingActionMenu />
-      <CTAButtonContainer>
-        <CTAButton to={viewModel.buildRouteForRepairCreatePage()} theme={theme} aria-label="새 정비 작업 시작하기">
-          + 새 정비 작업 시작
-        </CTAButton>
-      </CTAButtonContainer>
-      {viewModel.fabExpended && <ModalOverlay onClick={viewModel.toggleFab} />}
+      {(() => {
+        if (viewModel.shouldShowFAB) {
+          return <FloatingActionMenu />
+        }
+      })()}
+      {(() => {
+        if (viewModel.shouldShowCTA) {
+          return (
+            <CTAButtonContainer>
+              <CTAButton to={viewModel.buildRouteForRepairCreatePage()}>정비이력 등록하기</CTAButton>
+            </CTAButtonContainer>
+          )
+        }
+      })()}
+      {(() => {
+        if (viewModel.fabExpended) {
+          return <ModalOverlay onClick={viewModel.toggleFab} />
+        }
+      })()}
     </Container>
   )
 })
@@ -213,7 +225,8 @@ const Container = styled.main`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  padding-bottom: 80px; /* 하단 버튼 높이만큼 패딩 추가 */
+  padding-bottom: ${({ shouldShowCTA }: { shouldShowCTA: boolean }) =>
+    shouldShowCTA ? '80px' : '0'}; /* 하단 버튼 높이만큼 패딩 추가 */
 `
 
 const StickyTop = styled.div`

--- a/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewModel.ts
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router'
 
 import { buildRoute } from '@/application/routers/routes'
 import { RepairModel, VehicleModel } from '@/domain/models/models'
+import { useUserRole } from '@/presentation/hooks/hooks'
 
 export enum TabId {
   REPAIRS = 'repairs',
@@ -169,6 +170,7 @@ const store = new RepairsStore()
 
 export function useRepairsViewModel() {
   const [searchParams] = useSearchParams()
+  const { isAdmin, isRepairer, isUser, isGuardian } = useUserRole()
   const vehicleId = searchParams.get('vehicleId') ?? ''
 
   const buildRouteForRepairCreatePage = () => {
@@ -187,6 +189,9 @@ export function useRepairsViewModel() {
     return buildRoute('VEHICLE_TEST', {}, { vehicleId: vehicleId })
   }
 
+  const shouldShowCTA = isAdmin || isRepairer
+  const shouldShowFAB = isUser || isGuardian
+
   return {
     ...store,
     vehicleId,
@@ -198,5 +203,8 @@ export function useRepairsViewModel() {
     buildRouteForRepairDetailPage,
     buildRouteForRepairStationsPage,
     buildRouteForVehicleTestPage,
+    isUser,
+    shouldShowCTA,
+    shouldShowFAB,
   }
 }


### PR DESCRIPTION
## 사용자 권한을 분리합니다
- `ProtectedRoutes`에서 사용하던 `useAuthState()` hook을 전역으로 빼두고, 이를 `useUserRole()`에서도 사용하도록 하였습니다
- Repair Create는 admin | repairer만 가능합니다
- FAB는 user | guardian에게만 보입니다