### PR TITLE
fix: AuthPhoneVerifyUseCase for recaptcha error

### DIFF
--- a/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
+++ b/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
@@ -25,6 +25,7 @@ export const SignInPageViewMobile = observer(() => {
 
   return (
     <Container>
+      <RecaptchaVerifierContainer id={RECAPTCHA_VERIFIER_ID} />
       <Header title="번호 인증" onBack={viewModel.goBack} />
       <MainContent>
         <PhoneInputFormGroup />
@@ -83,7 +84,6 @@ const PhoneInputFormGroup = observer(() => {
           disabled={!viewModel.canRequestVerification}
           aria-disabled={!viewModel.canRequestVerification}
         >
-          <RecaptchaVerifier id={RECAPTCHA_VERIFIER_ID} tabIndex={-1} />
           {'인증번호 요청'}
         </RequestButton>
       </InputGroup>
@@ -235,6 +235,10 @@ const Container = styled.div`
   height: 100vh;
 `
 
+const RecaptchaVerifierContainer = styled.div`
+  display: none;
+`
+
 const MainContent = styled.div`
   flex: 1;
   padding: 28px 27px;
@@ -353,10 +357,6 @@ const RequestButton = styled.button`
   &:disabled {
     cursor: not-allowed;
   }
-`
-
-const RecaptchaVerifier = styled.span`
-  display: none;
 `
 
 const DateInputWrapper = styled.div`


### PR DESCRIPTION
## `Error: reCAPTCHA has already been rendered in this element` 에러를 수정합니다
- https://stackoverflow.com/questions/51285008/firebase-recaptchaverifier-clear-has-no-effect#:~:text=if%20%28this.applicationVerifier%20%26%26%20this.recaptchaWrapperRef%29%20,container%22%3E%3C%2Fdiv%3E%60

**오류 발생 시 다음과 같이 처리합니다**
1. 기존 reCAPTCHA 인스턴스 정리(clear())
2. reCAPTCHA 컨테이너 비우기(innerHTML = '')
3. 새로운 RecaptchaVerifier 인스턴스 생성
4. 다시 인증 시도