### PR TITLE
fix: Refactor styled components

### DIFF
--- a/src/presentation/pages/HomePage/HomePageViewMobile.tsx
+++ b/src/presentation/pages/HomePage/HomePageViewMobile.tsx
@@ -1,10 +1,9 @@
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Link, useSearchParams } from 'react-router'
 
 import { buildRoute } from '@/application/routers/routes'
 import { WordMark } from '@/assets/images/images'
-import { SOORITheme } from '@/theme/theme'
 
 export function HomePageViewMobile() {
   const theme = useTheme()
@@ -26,18 +25,18 @@ export function HomePageViewMobile() {
   )
 }
 
-const Container = styled.main`
+const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  height: 100vh;
   padding: 100px 25px;
   gap: 24px 0px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.secondary};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.secondary};
 `
 
-const MainContent = styled.div`
+const MainContent = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -61,9 +60,9 @@ const LoginButton = styled(Link)`
   width: 270px;
   height: 45px;
   border-radius: 6px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.tertiary};
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurface};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.tertiary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurface};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `

--- a/src/presentation/pages/RepairCreatePage/RepairCreatePageViewMobile.tsx
+++ b/src/presentation/pages/RepairCreatePage/RepairCreatePageViewMobile.tsx
@@ -1,11 +1,10 @@
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 
 import { Calendar, Setting, User } from '@/assets/svgs/svgs'
 import { REPAIR_CATEGORIES } from '@/domain/models/models'
 import { Header } from '@/presentation/components/components'
-import { SOORITheme } from '@/theme/theme'
 
 import { useRepairCreateViewModel } from './RepairCreatePageViewModel'
 
@@ -18,7 +17,7 @@ export const RepairCreatePageViewMobile = observer(() => {
       <StickyTop theme={theme}>
         <Header title="전동보장구 정비사항 작성" description="PM2024007 • 라이언" onBack={viewModel.goBack} />
       </StickyTop>
-      <MainContent role="main">
+      <MainContent>
         <BasicInfoSection />
         <RepairInfoSection />
       </MainContent>
@@ -277,7 +276,7 @@ const RepairMemoFormGroup = observer(() => {
   )
 })
 
-const Container = styled.main`
+const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   display: flex;
@@ -290,10 +289,10 @@ const StickyTop = styled.div`
   top: 0;
   width: 100%;
   z-index: 10;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.background};
 `
 
-const MainContent = styled.section`
+const MainContent = styled.main`
   flex: 1;
   padding: 15px 16px;
   padding-bottom: 80px; /* 하단 버튼 높이만큼 패딩 추가 */
@@ -310,7 +309,7 @@ const SectionHeader = styled.div`
   gap: 8px;
   padding: 7px 13px;
   border-radius: 12px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.outlineVariant};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.outlineVariant};
 `
 
 const IconContainer = styled.div`
@@ -341,14 +340,14 @@ const FormInput = styled.input`
   width: 100%;
   padding: 3px 12px;
   height: 42px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
   `}
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -358,14 +357,14 @@ const ButtonGroup = styled.div`
   width: 100%;
 `
 
-const SelectButton = styled.button<{ selected: boolean }>`
+const SelectButton = styled.button`
   flex: 1;
   padding: 3px 12px;
   border-radius: 6px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme; selected: boolean }) => theme.colors.primary};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+  border: 0.8px solid ${({ theme }: { theme: Theme; selected: boolean }) => theme.colors.primary};
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
     selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
     selected ? theme.colors.onSurface : theme.colors.primary};
   cursor: pointer;
   transition: all 0.2s ease;
@@ -381,15 +380,25 @@ const CategoryGrid = styled.div`
   justify-content: center;
 `
 
-const CategoryButton = styled.button<{ selected: boolean }>`
+const CategoryButton = styled.button`
   flex: 1;
   padding: 3px 12px;
   border-radius: 6px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme; selected: boolean }) => theme.colors.outline};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.onSurface : theme.colors.onSurfaceVariant};
+  border: 0.8px solid ${({ theme }: { theme: Theme; selected: boolean }) => theme.colors.outline};
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.primary
+    } else {
+      return theme.colors.background
+    }
+  }};
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.onSurfaceVariant
+    }
+  }};
   cursor: pointer;
   transition: all 0.2s ease;
   ${({ theme }) => css`
@@ -400,7 +409,7 @@ const CategoryButton = styled.button<{ selected: boolean }>`
 const TextArea = styled.textarea`
   width: 100%;
   padding: 12px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   resize: none;
   ${({ theme }) => css`
@@ -408,7 +417,7 @@ const TextArea = styled.textarea`
   `}
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -423,8 +432,8 @@ const CTAButtonContainer = styled.div`
   height: 80px;
   padding: 12px 25px;
   z-index: 5;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.surfaceContainer};
-  border-top: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.surfaceContainer};
+  border-top: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const CTAButton = styled.button`
@@ -434,11 +443,21 @@ const CTAButton = styled.button`
   width: 100%;
   height: 100%;
   border-radius: 12px;
-  background-color: ${({ theme, disabled }: { theme: SOORITheme; disabled: boolean }) =>
-    disabled ? theme.colors.onSurfaceVariant : theme.colors.primary};
-  color: ${({ theme, disabled }: { theme: SOORITheme; disabled?: boolean }) =>
-    disabled ? theme.colors.onSurface : theme.colors.background};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  background-color: ${({ theme, disabled }: { theme: Theme; disabled: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurfaceVariant
+    } else {
+      return theme.colors.primary
+    }
+  }};
+  color: ${({ theme, disabled }: { theme: Theme; disabled?: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.background
+    }
+  }};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyLarge};
   `}
   transition: all 0.2s ease;
@@ -457,7 +476,7 @@ const DateInput = styled.input`
   width: 100%;
   padding: 3px 12px;
   height: 42px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   position: relative;
   ${({ theme }) => css`
@@ -481,7 +500,7 @@ const DateInput = styled.input`
   }
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 

--- a/src/presentation/pages/RepairDetailPage/RepairDetailPageViewMobile.tsx
+++ b/src/presentation/pages/RepairDetailPage/RepairDetailPageViewMobile.tsx
@@ -1,11 +1,10 @@
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 
 import { Setting, User } from '@/assets/svgs/svgs'
 import { REPAIR_CATEGORIES } from '@/domain/models/repair_model'
 import { Header } from '@/presentation/components/Header'
-import { SOORITheme } from '@/theme/soori_theme'
 
 import { useRepairDetailViewModel } from './RepairDetailPageViewModel'
 
@@ -22,7 +21,7 @@ export const RepairDetailPageViewMobile = observer(() => {
           onBack={viewModel.goBack}
         />
       </StickyTop>
-      <MainContent role="main">
+      <MainContent>
         <BasicInfoSection />
         <RepairInfoSection />
       </MainContent>
@@ -203,7 +202,7 @@ const RepairMemoFormGroup = observer(() => {
   )
 })
 
-const Container = styled.main`
+const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   display: flex;
@@ -216,10 +215,10 @@ const StickyTop = styled.div`
   top: 0;
   width: 100%;
   z-index: 10;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.background};
 `
 
-const MainContent = styled.section`
+const MainContent = styled.main`
   flex: 1;
   padding: 15px 16px;
   padding-bottom: 80px; /* 하단 버튼 높이만큼 패딩 추가 */
@@ -236,7 +235,7 @@ const SectionHeader = styled.div`
   gap: 8px;
   padding: 7px 13px;
   border-radius: 12px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.outlineVariant};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.outlineVariant};
 `
 
 const IconContainer = styled.div`
@@ -269,9 +268,9 @@ const ReadonlyValue = styled.div`
   height: 42px;
   display: flex;
   align-items: center;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.primary};
   border-radius: 6px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.secondary};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.secondary};
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
   `}
@@ -284,15 +283,25 @@ const CategoryGrid = styled.div`
   justify-content: center;
 `
 
-const CategoryBadge = styled.div<{ selected: boolean }>`
+const CategoryBadge = styled.div`
   flex: 1;
   padding: 3px 12px;
   border-radius: 6px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme; selected: boolean }) => theme.colors.outline};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.onSurface : theme.colors.onSurfaceVariant};
+  border: 0.8px solid ${({ theme }: { theme: Theme; selected: boolean }) => theme.colors.outline};
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.primary
+    } else {
+      return theme.colors.background
+    }
+  }};
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.onSurfaceVariant
+    }
+  }};
   transition: all 0.2s ease;
   ${({ theme }) => css`
     ${theme.typography.labelSmall};
@@ -302,9 +311,9 @@ const CategoryBadge = styled.div<{ selected: boolean }>`
 const ReadonlyTextArea = styled.textarea`
   width: 100%;
   padding: 12px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.primary};
   border-radius: 6px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.secondary};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.secondary};
   resize: none;
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
@@ -313,7 +322,7 @@ const ReadonlyTextArea = styled.textarea`
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+    border-color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
   }
 `
 
@@ -323,16 +332,16 @@ const ButtonGroup = styled.div`
   width: 100%;
 `
 
-const ReadonlySelectButton = styled.button<{ selected: boolean }>`
+const ReadonlySelectButton = styled.button`
   flex: 1;
   padding: 3px 12px;
   border-radius: 6px;
   border: 0.8px solid
-    ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+    ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
       selected ? theme.colors.primary : theme.colors.outline};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
     selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
     selected ? theme.colors.onSurface : theme.colors.onSurfaceVariant};
   cursor: default;
   ${({ theme }) => css`

--- a/src/presentation/pages/RepairStationsPage/RepairStationsPageViewMobile.tsx
+++ b/src/presentation/pages/RepairStationsPage/RepairStationsPageViewMobile.tsx
@@ -1,10 +1,9 @@
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 
 import { ChevronRight } from '@/assets/svgs/svgs'
 import { Header } from '@/presentation/components/components'
-import { SOORITheme } from '@/theme/theme'
 
 import { SortType, useRepairStationsViewModel } from './RepairStationsPageViewModel'
 
@@ -56,7 +55,7 @@ export const RepairStationsPageViewMobile = observer(() => {
   )
 })
 
-const Container = styled.main`
+const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   display: flex;
@@ -69,10 +68,10 @@ const StickyTop = styled.div`
   top: 0;
   width: 100%;
   z-index: 10;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.background};
 `
 
-const MainContent = styled.section`
+const MainContent = styled.main`
   flex: 1;
 `
 
@@ -80,20 +79,29 @@ const SortFilterContainer = styled.div`
   display: flex;
   padding: 12px 16px;
   gap: 10px;
-  border-bottom: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border-bottom: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
-const SortChip = styled.button<{ selected: boolean }>`
+const SortChip = styled.button`
   padding: 8px 16px;
   border-radius: 16px;
   border: 0.8px solid
-    ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
+    ${({ theme, selected }: { theme: Theme; selected: boolean }) =>
       selected ? theme.colors.primary : theme.colors.outline};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.onSurface : theme.colors.onSurfaceVariant};
-  cursor: pointer;
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.primary
+    } else {
+      return theme.colors.background
+    }
+  }};
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.onSurfaceVariant
+    }
+  }};
   transition: all 0.2s ease;
   ${({ theme }) => css`
     ${theme.typography.labelSmall};
@@ -111,16 +119,16 @@ const StationItem = styled.li`
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurface};
+  border-bottom: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.onSurface};
   cursor: pointer;
 `
 
 const StationName = styled.p`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.tertiary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.tertiary};
 `
 
 const StationInfoContainer = styled.div`
@@ -130,10 +138,10 @@ const StationInfoContainer = styled.div`
 `
 
 const StationDistrict = styled.span`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
 `
 
 const ChevronIconContainer = styled.div`

--- a/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
+++ b/src/presentation/pages/RepairsPage/RepairsPageViewMobile.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 import { Link } from 'react-router'
@@ -8,7 +8,6 @@ import { Link } from 'react-router'
 import { Add, Calendar, Cancel, Check, ChevronRight, Map, Search } from '@/assets/svgs/svgs'
 import { RepairModel } from '@/domain/models/models'
 import { Header, Tabs } from '@/presentation/components/components'
-import { SOORITheme } from '@/theme/theme'
 
 import { TabId, useRepairsViewModel } from './RepairsPageViewModel'
 
@@ -36,7 +35,7 @@ export const RepairsPageViewMobile = observer(() => {
         />
         <SearchBar />
       </StickyTop>
-      <MainContent role="main">
+      <MainContent>
         {(() => {
           if (viewModel.activeTab === TabId.REPAIRS) {
             return <RepairHistoryList />
@@ -220,7 +219,7 @@ const Vehicle = () => {
   )
 }
 
-const Container = styled.main`
+const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   display: flex;
@@ -234,10 +233,10 @@ const StickyTop = styled.div`
   top: 0;
   width: 100%;
   z-index: 10;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.background};
 `
 
-const MainContent = styled.section`
+const MainContent = styled.main`
   flex: 1;
 `
 
@@ -246,9 +245,9 @@ const SearchBarOuterContainer = styled.div`
   justify-content: center;
   align-items: center;
   height: 46px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.surfaceContainer};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.surfaceContainer};
   padding: 8px 11px;
-  border-bottom: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border-bottom: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const SearchBarInnerContainer = styled.div`
@@ -257,8 +256,8 @@ const SearchBarInnerContainer = styled.div`
   height: 100%;
   padding: 7px 10px;
   border-radius: 12px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurface};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.onSurface};
 `
 
 const IconContainer = styled.div`
@@ -273,13 +272,13 @@ const SearchInput = styled.input`
   border: none;
   padding: 8px;
   background-color: transparent;
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.tertiary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.tertiary};
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -294,8 +293,8 @@ const CTAButtonContainer = styled.div`
   height: 80px;
   padding: 12px 25px;
   z-index: 5;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.surfaceContainer};
-  border-top: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.surfaceContainer};
+  border-top: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const CTAButton = styled(Link)`
@@ -305,9 +304,9 @@ const CTAButton = styled(Link)`
   width: 100%;
   height: 100%;
   border-radius: 12px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.background};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyLarge};
   `}
 `
@@ -323,9 +322,9 @@ const RepairCard = styled(Link)`
   flex-direction: column;
   height: 100px;
   gap: 11px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurface};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.onSurface};
   padding: 15px 21px;
-  border-bottom: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border-bottom: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const RepairCardHeader = styled.div`
@@ -342,10 +341,10 @@ const RepairDateContainer = styled.div`
 `
 
 const RepairDate = styled.span`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
 `
 
 const RepairBillingPriceContainer = styled.div`
@@ -355,7 +354,7 @@ const RepairBillingPriceContainer = styled.div`
 `
 
 const RepairBillingPrice = styled.p`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `
@@ -367,19 +366,19 @@ const RepairTypeBadge = styled.span`
   width: 100px;
   height: 16px;
   margin: 1px 0px;
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
   border-radius: 4px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.primary};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.labelSmall};
   `}
 `
 
 const RepairShop = styled.p`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   height: 15px;
 `
 
@@ -389,7 +388,7 @@ const VehicleCard = styled.div`
   margin: 40px 26px;
   padding: 15px 12px 45px 12px;
   border-radius: 24px;
-  border: 1px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 1px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const VehicleInfoRow = styled.dl`
@@ -400,14 +399,14 @@ const VehicleInfoRow = styled.dl`
 `
 
 const VehicleInfoLabel = styled.dt`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
 `
 
 const VehicleInfoValue = styled.dd`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `
@@ -415,7 +414,7 @@ const VehicleInfoValue = styled.dd`
 const Divider = styled.div`
   width: 100%;
   height: 0.8px;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const FloatingMenuContainer = styled.div`
@@ -449,9 +448,9 @@ const MenuItem = styled(Link)`
   align-items: center;
   padding: 0px 16px 0px 0px;
   background-color: transparent;
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
   cursor: pointer;
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `
@@ -464,11 +463,11 @@ const MenuItemIconContainer = styled.div`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
 `
 
 const MenuItemText = styled.span`
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `
@@ -481,14 +480,14 @@ const FABContainer = styled.button`
   height: 40px;
   border: none;
   border-radius: 50%;
-  background-color: ${({ theme, fabExpended }: { theme: SOORITheme; fabExpended?: boolean }) => {
+  background-color: ${({ theme, fabExpended }: { theme: Theme; fabExpended?: boolean }) => {
     if (fabExpended) {
       return theme.colors.outlineVariant
     } else {
       return theme.colors.primary
     }
   }};
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.background};
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
   cursor: pointer;
   transition: transform 0.3s ease;

--- a/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
+++ b/src/presentation/pages/SignInPage/SignInPageViewMobile.tsx
@@ -1,13 +1,12 @@
 import { useEffect } from 'react'
 
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 
 import { Calendar } from '@/assets/svgs/svgs'
 import { RECAPTCHA_VERIFIER_ID } from '@/domain/use_cases/use_cases'
 import { Header } from '@/presentation/components/components'
-import { SOORITheme } from '@/theme/theme'
 
 import { useSignInViewModel } from './SignInPageViewModel'
 
@@ -246,7 +245,7 @@ const Container = styled.div`
   height: 100vh;
 `
 
-const MainContent = styled.div`
+const MainContent = styled.main`
   flex: 1;
   padding: 28px 27px;
   padding-bottom: 80px; /* 하단 버튼 높이만큼 패딩 추가 */
@@ -259,7 +258,7 @@ const FormGroup = styled.div`
 
 const FormLabel = styled.label`
   display: block;
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.labelSmall};
   `}
 `
@@ -273,14 +272,14 @@ const FormInput = styled.input`
   width: 100%;
   padding: 3px 12px;
   height: 42px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
   `}
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -290,14 +289,20 @@ const PhoneInput = styled.input`
   padding: 3px 12px;
   height: 42px;
   border: 0.8px solid
-    ${({ theme, error }: { theme: SOORITheme; error: boolean }) => (error ? theme.colors.error : theme.colors.outline)};
+    ${({ theme, error }: { theme: Theme; error: boolean }) => {
+      if (error) {
+        return theme.colors.error
+      } else {
+        return theme.colors.outline
+      }
+    }};
   border-radius: 6px;
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
   `}
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -305,14 +310,20 @@ const VerificationInputContainer = styled.div`
   flex: 1;
   position: relative;
   border: 0.8px solid
-    ${({ theme, error }: { theme: SOORITheme; error: boolean }) => (error ? theme.colors.error : theme.colors.outline)};
+    ${({ theme, error }: { theme: Theme; error: boolean }) => {
+      if (error) {
+        return theme.colors.error
+      } else {
+        return theme.colors.outline
+      }
+    }};
   border-radius: 6px;
   display: flex;
   align-items: center;
 
   &:focus-within {
-    border-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.tertiary};
-    outline: 2px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.tertiary};
+    border-color: ${({ theme }: { theme: Theme }) => theme.colors.tertiary};
+    outline: 2px solid ${({ theme }: { theme: Theme }) => theme.colors.tertiary};
     outline-offset: -1px;
   }
 `
@@ -329,7 +340,7 @@ const VerificationInput = styled.input`
   `}
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 
   &:focus {
@@ -340,9 +351,14 @@ const VerificationInput = styled.input`
 const TimerOverlay = styled.div`
   position: absolute;
   right: 12px;
-  ${({ theme }: { theme: SOORITheme }) => theme.typography.bodyMedium};
-  color: ${({ theme, expired }: { theme: SOORITheme; expired: boolean }) =>
-    expired ? theme.colors.error : theme.colors.primary};
+  ${({ theme }: { theme: Theme }) => theme.typography.bodyMedium};
+  color: ${({ theme, expired }: { theme: Theme; expired: boolean }) => {
+    if (expired) {
+      return theme.colors.error
+    } else {
+      return theme.colors.primary
+    }
+  }};
 `
 
 const VisibleOnly = styled.span``
@@ -360,8 +376,8 @@ const ScreenReaderOnly = styled.span`
 
 const ErrorMessage = styled.p`
   margin-top: 2px;
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.error};
-  ${({ theme }: { theme: SOORITheme }) => theme.typography.labelSmall};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.error};
+  ${({ theme }: { theme: Theme }) => theme.typography.labelSmall};
 `
 
 const RequestButton = styled.button`
@@ -372,11 +388,21 @@ const RequestButton = styled.button`
   padding: 0 8px;
   border-radius: 6px;
   border: none;
-  background-color: ${({ theme, disabled }: { theme: SOORITheme; disabled: boolean }) =>
-    disabled ? theme.colors.onSurfaceVariant : theme.colors.primary};
-  color: ${({ theme, disabled }: { theme: SOORITheme; disabled: boolean }) =>
-    disabled ? theme.colors.outlineVariant : theme.colors.onSurface};
-  ${({ theme }: { theme: SOORITheme }) => theme.typography.bodyMedium};
+  background-color: ${({ theme, disabled }: { theme: Theme; disabled: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurfaceVariant
+    } else {
+      return theme.colors.primary
+    }
+  }};
+  color: ${({ theme, disabled }: { theme: Theme; disabled: boolean }) => {
+    if (disabled) {
+      return theme.colors.outlineVariant
+    } else {
+      return theme.colors.onSurface
+    }
+  }};
+  ${({ theme }: { theme: Theme }) => theme.typography.bodyMedium};
 
   &:disabled {
     cursor: not-allowed;
@@ -396,7 +422,7 @@ const DateInput = styled.input`
   width: 100%;
   padding: 3px 12px;
   height: 42px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   position: relative;
   ${({ theme }) => css`
@@ -420,7 +446,7 @@ const DateInput = styled.input`
   }
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `
 
@@ -446,8 +472,8 @@ const CTAButtonContainer = styled.div`
   height: 80px;
   padding: 12px 25px;
   z-index: 5;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.surfaceContainer};
-  border-top: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.surfaceContainer};
+  border-top: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const CTAButton = styled.button`
@@ -457,11 +483,21 @@ const CTAButton = styled.button`
   width: 100%;
   height: 100%;
   border-radius: 12px;
-  background-color: ${({ theme, disabled }: { theme: SOORITheme; disabled: boolean }) =>
-    disabled ? theme.colors.onSurfaceVariant : theme.colors.primary};
-  color: ${({ theme, disabled }: { theme: SOORITheme; disabled?: boolean }) =>
-    disabled ? theme.colors.onSurface : theme.colors.background};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  background-color: ${({ theme, disabled }: { theme: Theme; disabled: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurfaceVariant
+    } else {
+      return theme.colors.primary
+    }
+  }};
+  color: ${({ theme, disabled }: { theme: Theme; disabled?: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.background
+    }
+  }};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyLarge};
   `}
   transition: all 0.2s ease;
@@ -479,7 +515,7 @@ const SelectBox = styled.select`
   width: 100%;
   padding: 3px 12px;
   height: 42px;
-  border: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
   border-radius: 6px;
   ${({ theme }) => css`
     ${theme.typography.bodySmall};
@@ -490,6 +526,6 @@ const SelectBox = styled.select`
   cursor: pointer;
 
   &::placeholder {
-    color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurfaceVariant};
+    color: ${({ theme }: { theme: Theme }) => theme.colors.onSurfaceVariant};
   }
 `

--- a/src/presentation/pages/VehicleTestPage/VehicleTestPageViewMobile.tsx
+++ b/src/presentation/pages/VehicleTestPage/VehicleTestPageViewMobile.tsx
@@ -1,9 +1,8 @@
-import { css, useTheme } from '@emotion/react'
+import { css, useTheme, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { observer } from 'mobx-react-lite'
 
 import { Header } from '@/presentation/components/components'
-import { SOORITheme } from '@/theme/theme'
 
 import { useVehicleTestViewModel } from './VehicleTestPageViewModel'
 
@@ -16,7 +15,7 @@ export const VehicleTestPageViewMobile = observer(() => {
       <StickyTop theme={theme}>
         <Header title="나의 전동보장구 자가점검" onBack={viewModel.goBack} />
       </StickyTop>
-      <MainContent role="main">
+      <MainContent>
         <TestItemList aria-label="자가점검 항목 목록">
           {viewModel.testItems.map((item) => (
             <TestItem key={item.id} theme={theme}>
@@ -77,7 +76,7 @@ const StickyTop = styled.div`
   top: 0;
   width: 100%;
   z-index: 10;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.background};
 `
 
 const MainContent = styled.section`
@@ -95,7 +94,7 @@ const TestItem = styled.li`
   display: flex;
   align-items: flex-start;
   padding: 16px 0;
-  border-bottom: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  border-bottom: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
 const TestItemNumber = styled.span`
@@ -105,10 +104,10 @@ const TestItemNumber = styled.span`
   min-width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.primary};
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.onSurface};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.primary};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.onSurface};
   margin-right: 12px;
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
 `
@@ -123,7 +122,7 @@ const TestItemRow = styled.div`
 const TestItemQuestion = styled.p`
   flex: 1;
   padding-right: 10px;
-  ${({ theme }: { theme: SOORITheme }) => css`
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyMedium};
   `}
   word-break: keep-all;
@@ -134,17 +133,31 @@ const TestItemAnswers = styled.div`
   gap: 10px;
 `
 
-const AnswerButton = styled.button<{ selected: boolean }>`
+const AnswerButton = styled.button`
   padding: 8px 16px;
   border-radius: 6px;
   border: 0.8px solid
-    ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-      selected ? theme.colors.primary : theme.colors.outline};
-  background-color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, selected }: { theme: SOORITheme; selected: boolean }) =>
-    selected ? theme.colors.onSurface : theme.colors.onSurfaceVariant};
-  cursor: pointer;
+    ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+      if (selected) {
+        return theme.colors.primary
+      } else {
+        return theme.colors.outline
+      }
+    }};
+  background-color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.primary
+    } else {
+      return theme.colors.background
+    }
+  }};
+  color: ${({ theme, selected }: { theme: Theme; selected: boolean }) => {
+    if (selected) {
+      return theme.colors.onSurface
+    } else {
+      return theme.colors.onSurfaceVariant
+    }
+  }};
   transition: all 0.2s ease;
   ${({ theme }) => css`
     ${theme.typography.labelSmall};
@@ -162,11 +175,11 @@ const CTAButtonContainer = styled.div`
   height: 80px;
   padding: 12px 25px;
   z-index: 5;
-  background-color: ${({ theme }: { theme: SOORITheme }) => theme.colors.surfaceContainer};
-  border-top: 0.8px solid ${({ theme }: { theme: SOORITheme }) => theme.colors.outline};
+  background-color: ${({ theme }: { theme: Theme }) => theme.colors.surfaceContainer};
+  border-top: 0.8px solid ${({ theme }: { theme: Theme }) => theme.colors.outline};
 `
 
-const CTAButton = styled.button<{ disabled: boolean }>`
+const CTAButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -174,12 +187,29 @@ const CTAButton = styled.button<{ disabled: boolean }>`
   height: 100%;
   border-radius: 12px;
   border: none;
-  background-color: ${({ theme, disabled }: { theme: SOORITheme; disabled: boolean }) =>
-    disabled ? theme.colors.onSurfaceVariant : theme.colors.primary};
-  color: ${({ theme }: { theme: SOORITheme }) => theme.colors.background};
-  opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  ${({ theme }: { theme: SOORITheme }) => css`
+  background-color: ${({ theme, disabled }: { theme: Theme; disabled: boolean }) => {
+    if (disabled) {
+      return theme.colors.onSurfaceVariant
+    } else {
+      return theme.colors.primary
+    }
+  }};
+  color: ${({ theme }: { theme: Theme }) => theme.colors.background};
+  opacity: ${({ disabled }) => {
+    if (disabled) {
+      return 0.6
+    } else {
+      return 1
+    }
+  }};
+  cursor: ${({ disabled }) => {
+    if (disabled) {
+      return 'not-allowed'
+    } else {
+      return 'pointer'
+    }
+  }};
+  ${({ theme }: { theme: Theme }) => css`
     ${theme.typography.bodyLarge};
   `}
 `


### PR DESCRIPTION
## styled component를 사용하는 방식을 통일합니다
- Container는 `<div>`, MainContent는 `<main>` 태그를 사용합니다
- 길이가 길어지는 삼항연산자는 if문을 사용하도록 합니다
- `SooriTheme` 타입 대신, @emotion/react의 `Theme` 타입을 사용합니다