### PR TITLE
fix: Update vehicleId logic for user and guardian roles

### DIFF
--- a/src/application/routers/ProtectedRoutes.tsx
+++ b/src/application/routers/ProtectedRoutes.tsx
@@ -50,7 +50,6 @@ export const ProtectedRoute = ({ children, requireAuth }: ProtectedRouteProps) =
   useEffect(() => {
     if (!userRole || !vehicle || isVehicleLoading) return
 
-    // user 또는 guardian 역할일 때만 vehicleId 업데이트 로직 실행
     if (!isUser && !isGuardian) return
 
     const currentVehicleId = new URLSearchParams(location.search).get('vehicleId')


### PR DESCRIPTION
## ProtectedRoutes에서 vehicleId를 업데이트하는 로직을 수정합니다
- role이 user 혹은 guardian일 경우에만 해당 로직이 작동하도록 하였습니다