### PR TITLE
fix: Disable firebase app verification

### DIFF
--- a/src/application/configurations/firebase/firebase.config.ts
+++ b/src/application/configurations/firebase/firebase.config.ts
@@ -1,5 +1,6 @@
 import { FirebaseOptions, initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
+import firebase from 'firebase/compat/app'
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -12,5 +13,7 @@ const firebaseConfig: FirebaseOptions = {
 }
 
 export const app = initializeApp(firebaseConfig)
+
+firebase.auth().settings.appVerificationDisabledForTesting = true
 
 export const auth = getAuth(app)

--- a/src/application/configurations/firebase/firebase.config.ts
+++ b/src/application/configurations/firebase/firebase.config.ts
@@ -1,6 +1,5 @@
 import { FirebaseOptions, initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
-import firebase from 'firebase/compat/app'
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -14,6 +13,6 @@ const firebaseConfig: FirebaseOptions = {
 
 export const app = initializeApp(firebaseConfig)
 
-firebase.auth().settings.appVerificationDisabledForTesting = true
-
 export const auth = getAuth(app)
+
+auth.settings.appVerificationDisabledForTesting = true


### PR DESCRIPTION
## firebase authentication에서 recpatcha 인증을 생략합니다
- https://stackoverflow.com/questions/40563140/error-no-firebase-app-default-has-been-created-call-firebase-app-initiali
- 테스트가 필요합니다