### PR TITLE
fix: `goBack()` method in pages

### DIFF
--- a/src/presentation/pages/RepairStationsPage/RepairStationsPageViewModel.ts
+++ b/src/presentation/pages/RepairStationsPage/RepairStationsPageViewModel.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable } from 'mobx'
-import { useNavigate } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 
+import { buildRoute } from '@/application/routers/routes'
 import { useRepairStations } from '@/presentation/hooks/hooks'
 
 export enum SortType {
@@ -23,6 +24,8 @@ const store = new RepairStationsStore()
 export function useRepairStationsViewModel() {
   const navigate = useNavigate()
   const { data: repairStations } = useRepairStations()
+  const [searchParams] = useSearchParams()
+  const vehicleId = searchParams.get('vehicleId') ?? ''
 
   const sortedRepairStations = (() => {
     if (!repairStations) return []
@@ -49,7 +52,7 @@ export function useRepairStationsViewModel() {
   }
 
   const goBack = () => {
-    void navigate(-1)
+    void navigate(buildRoute('REPAIRS', {}, { vehicleId: vehicleId }))
   }
 
   return {

--- a/src/presentation/pages/VehicleSelfCheckPage/VehicleSelfCheckPageViewModel.ts
+++ b/src/presentation/pages/VehicleSelfCheckPage/VehicleSelfCheckPageViewModel.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { makeAutoObservable } from 'mobx'
 import { useNavigate, useSearchParams } from 'react-router'
 
+import { buildRoute } from '@/application/routers/routes'
 import { SelfCheckModel } from '@/domain/models/models'
 import { useSelfCheck, useLoading } from '@/presentation/hooks/hooks'
 
@@ -182,7 +183,7 @@ export function useVehicleSelfCheckViewModel() {
   const { createSelfCheck, error: apiError, selfChecks } = useSelfCheck({ vehicleId })
 
   const goBack = () => {
-    void navigate(-1)
+    void navigate(buildRoute('REPAIRS', {}, { vehicleId: vehicleId }))
   }
 
   const queryClient = useQueryClient()


### PR DESCRIPTION
## 일부 페이지에서의 뒤로가기 동작을 수정합니다
- `navigate(-1)` 대신, repairs 페이지로 이동하도록 합니다.